### PR TITLE
Change speedmodifier

### DIFF
--- a/lua/totem/sh_init.lua
+++ b/lua/totem/sh_init.lua
@@ -1,7 +1,7 @@
 TTT2Totem = {}
 
 hook.Add("TTTPlayerSpeedModifier", "TTT2TotemSpeed", function(ply, _, _, noLag)
-	if not GetGlobalBool("ttt2_totem", false) or not GetGlobalBool("ttt2_totem_enable_speedmodifier", false) or not TTT2Totem.AnyTotems then return end
+	if not GetGlobalBool("ttt2_totem", false) or not TTT2Totem.AnyTotems then return end
 
 	local rs = GetRoundState()
 
@@ -10,7 +10,7 @@ hook.Add("TTTPlayerSpeedModifier", "TTT2TotemSpeed", function(ply, _, _, noLag)
 
 		if not ply.PlacedTotem then
 			mul = 0.4
-		else
+		elseif GetGlobalBool("ttt2_totem_enable_speedmodifier", true) then
 			local Totem = ply:GetTotem()
 
 			if IsValid(Totem) then


### PR DESCRIPTION
As of now the speedmodifier can be toggled on or entirely off. The problem is that the speedmodifier should still apply to players who did not place their totem at all, because as of now people can just not place their totem or pick it up again and do not get punished for it. I think the point of the speedmodifier is that the totems do not cause annoying slow down on very large maps (atleast that's the reason I originally requested it for). This PR would still apply the slowdown to players who did not place a totem, while removing it from players who have, meaning it is still a very good reminder while not causing issues at all on large maps once the totem was placed.