### PR TITLE
Fix bug caused when placing a totem in prep and remove unnecessary flag

### DIFF
--- a/lua/totem/cl_init.lua
+++ b/lua/totem/cl_init.lua
@@ -1,4 +1,4 @@
-CreateConVar("ttt_totem_auto", "1", {FCVAR_ARCHIVE}, "Should the system try to place the Totem automaticially after round start?")
+local totem_autoplace = CreateConVar("ttt_totem_auto", "1", {FCVAR_ARCHIVE}, "Should the system try to place the Totem automaticially after round start?")
 
 net.Receive("TTT2ClientInitTotem", function()
 	include("totem/client/cl_menu.lua")
@@ -32,7 +32,7 @@ local function AutoPlace()
 end
 
 hook.Add("TTTBeginRound", "TTT2TotemAutomaticPlacement", function()
-	if not GetGlobalBool("ttt2_totem", false) or not GetConVar("ttt_totem_auto"):GetBool() then return end
+	if not GetGlobalBool("ttt2_totem", false) or not totem_autoplace:GetBool() then return end
 
 	LocalPlayer().PlacedTotem = false
 

--- a/lua/totem/cl_init.lua
+++ b/lua/totem/cl_init.lua
@@ -23,7 +23,7 @@ concommand.Add("placetotem", LookUpTotem, nil, "Places a Totem", {FCVAR_DONTRECO
 local function AutoPlace()
 	local ply = LocalPlayer()
 
-	if not IsValid(ply) or not ply:IsTerror() or ply.PlacedTotem or GetRoundState() == ROUND_WAIT then
+	if not IsValid(ply) or not ply:IsTerror() or GetRoundState() == ROUND_WAIT or IsValid(ply:GetNWEntity("Totem", NULL)) then
 		timer.Remove("TTT2AutoPlaceTotem")
 		return
 	end
@@ -33,8 +33,6 @@ end
 
 hook.Add("TTTBeginRound", "TTT2TotemAutomaticPlacement", function()
 	if not GetGlobalBool("ttt2_totem", false) or not totem_autoplace:GetBool() then return end
-
-	LocalPlayer().PlacedTotem = false
 
 	AutoPlace()
 	timer.Create("TTT2AutoPlaceTotem", 2, 0, AutoPlace)
@@ -50,12 +48,8 @@ net.Receive("TTT2Totem", function()
 		chat.AddText("TTT2 Totem: ", COLOR_WHITE, GetTranslation("totem_place_ground_needed"))
 	elseif bool == 3 then
 		chat.AddText("TTT2 Totem: ", COLOR_WHITE, GetTranslation("totem_placed"))
-
-		LocalPlayer().PlacedTotem = true
 	elseif bool == 4 then
 		chat.AddText("TTT2 Totem: ", COLOR_WHITE, GetTranslation("totem_picked_up"))
-
-		LocalPlayer().PlacedTotem = false
 	elseif bool == 5 then
 		chat.AddText("TTT2 Totem: ", COLOR_WHITE, GetTranslation("totem_destroyed"))
 	elseif bool == 6 then
@@ -69,7 +63,7 @@ net.Receive("TTT2Totem", function()
 	chat.PlaySound()
 end)
 
-hook.Add( "PreDrawOutlines", "AddTotemOutlines", function()
+hook.Add("PreDrawOutlines", "AddTotemOutlines", function()
 	local totem = LocalPlayer():GetTotem()
 
 	if totem then

--- a/lua/totem/cl_init.lua
+++ b/lua/totem/cl_init.lua
@@ -1,4 +1,4 @@
-CreateConVar("ttt_totem_auto", "1", {FCVAR_ARCHIVE}, "Should the system try to place the Totem automaticially at round start?")
+CreateConVar("ttt_totem_auto", "1", {FCVAR_ARCHIVE}, "Should the system try to place the Totem automaticially after round start?")
 
 net.Receive("TTT2ClientInitTotem", function()
 	include("totem/client/cl_menu.lua")
@@ -10,13 +10,7 @@ hook.Add("TTT2FinishedLoading", "TTT2TotemInitLang", function()
 	end
 end)
 
-hook.Add("TTTBeginRound", "TTT2TotemAutomaticPlacement", function()
-	if not GetGlobalBool("ttt2_totem", false) or not GetConVar("ttt_totem_auto"):GetBool() then return end
-
-	LookUpTotem()
-end)
-
-function LookUpTotem(ply, cmd, args, argStr)
+local function LookUpTotem(ply, cmd, args, argStr)
 	if not GetGlobalBool("ttt2_totem", false) then return end
 
 	if GetRoundState() ~= ROUND_WAIT and LocalPlayer():IsTerror() then
@@ -25,6 +19,26 @@ function LookUpTotem(ply, cmd, args, argStr)
 	end
 end
 concommand.Add("placetotem", LookUpTotem, nil, "Places a Totem", {FCVAR_DONTRECORD})
+
+local function AutoPlace()
+	local ply = LocalPlayer()
+
+	if not IsValid(ply) or not ply:IsTerror() or ply.PlacedTotem or GetRoundState() == ROUND_WAIT then
+		timer.Remove("TTT2AutoPlaceTotem")
+		return
+	end
+
+	LookUpTotem()
+end
+
+hook.Add("TTTBeginRound", "TTT2TotemAutomaticPlacement", function()
+	if not GetGlobalBool("ttt2_totem", false) or not GetConVar("ttt_totem_auto"):GetBool() then return end
+
+	LocalPlayer().PlacedTotem = false
+
+	AutoPlace()
+	timer.Create("TTT2AutoPlaceTotem", 2, 0, AutoPlace)
+end)
 
 net.Receive("TTT2Totem", function()
 	local bool = net.ReadInt(8)


### PR DESCRIPTION
If you place a totem in preptime, the clientside PlacedTotem flag is overwritten at round start and the timer goes on forever. To prevent this, one could add a second hook to reset the flag at the TTTPrepareRound event. While implementing such a fix, I realized that I could just use the NWEntity instead and remove the flag entirely, since it is easily replaced by an IsValid check.