### PR TITLE
Replaced HasTeam

### DIFF
--- a/gamemodes/terrortown/entities/entities/ttt_totem/shared.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_totem/shared.lua
@@ -75,7 +75,7 @@ function ENT:OnTakeDamage(dmginfo)
 
 	local owner, att, infl = self:GetOwner(), dmginfo:GetAttacker(), dmginfo:GetInflictor()
 
-	if not IsValid(owner) or infl == owner or att == owner or owner:HasTeam(TEAM_TRAITOR) then return end
+	if not IsValid(owner) or infl == owner or att == owner or owner:GetTeam() == TEAM_TRAITOR then return end
 
 	if (infl:IsPlayer() and infl:GetSubRole() == ROLE_TOTEMHUNTER or att:IsPlayer() and att:GetSubRole() == ROLE_TOTEMHUNTER) and infl:GetClass() == "weapon_ttt_totemknife" then
 		if SERVER and owner:IsValid() and att:IsValid() and att:IsPlayer() then

--- a/lua/terrortown/autorun/server/sv_totem.lua
+++ b/lua/terrortown/autorun/server/sv_totem.lua
@@ -89,7 +89,7 @@ function TotemUpdate()
 		local innototems = {}
 
 		for _, v in ipairs(totems) do
-			if not v:HasTeam(TEAM_TRAITOR) then
+			if v:GetTeam() ~= TEAM_TRAITOR then
 				table.insert(innototems, v)
 			end
 		end

--- a/lua/terrortown/entities/roles/totemhunter/shared.lua
+++ b/lua/terrortown/entities/roles/totemhunter/shared.lua
@@ -56,7 +56,7 @@ if SERVER then
 				pos.z = math.Round(pos.z)
 
 				local owner = t:GetOwner()
-				if owner ~= ply and not owner:HasTeam(TEAM_TRAITOR) then
+				if owner ~= ply and owner:GetTeam() ~= TEAM_TRAITOR then
 					table.insert(targets, {subrole = -1, pos = pos})
 				end
 			end


### PR DESCRIPTION
This PR replaced `HasTeam` because it doesn't support parameter anymore since TTT2 v0.9.0b and GetTeam should be used instead.
This also fixes an issue which caused no Totems to appear sometimes (they would be destroyed instantly at round start).